### PR TITLE
allow nginx version to be set by env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: Build nginx image
           command: |
-            docker build --build-arg "NGINX_VERSION=${NGINX_VERSION:-latest}"" -t nginx-dynamic-acm -t "ci${CIRCLE_BUILD_NUM}"" . --progress plain
+            docker build --build-arg "NGINX_VERSION=${NGINX_VERSION:-latest}" -t nginx-dynamic-acm -t "ci${CIRCLE_BUILD_NUM}" . --progress plain
       - run:
           name: Push to Dockerhub and AWS ECR on master or prod
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.14
+          version: 20.10.18
       - run: pip install awscli pip --upgrade
       - run:
           name: Build nginx image
           command: |
-            docker build -t nginx-dynamic-acm . --progress plain
+            docker build --build-arg NGINX_VERSION=${NGINX_VERSION:-latest} -t nginx-dynamic-acm . --progress plain
       - run:
           name: Push to Dockerhub and AWS ECR on master or prod
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: Build nginx image
           command: |
-            docker build --build-arg "NGINX_VERSION=${NGINX_VERSION:-latest}" -t nginx-dynamic-acm -t "ci${CIRCLE_BUILD_NUM}" . --progress plain
+            docker build --build-arg "NGINX_VERSION=${NGINX_VERSION:-latest}" -t nginx-dynamic-acm -t "nginx-dynamic-acm:ci${CIRCLE_BUILD_NUM}" . --progress plain
       - run:
           name: Push to Dockerhub and AWS ECR on master or prod
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: Build nginx image
           command: |
-            docker build --build-arg NGINX_VERSION=${NGINX_VERSION:-latest} -t nginx-dynamic-acm . --progress plain
+            docker build --build-arg "NGINX_VERSION=${NGINX_VERSION:-latest}"" -t nginx-dynamic-acm -t "ci${CIRCLE_BUILD_NUM}"" . --progress plain
       - run:
           name: Push to Dockerhub and AWS ECR on master or prod
           command: |


### PR DESCRIPTION
## Description of the change

Allow nginx version to be set by env var. Still defaults to latest if env var is not present.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

For production level repositories:

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests.
- [ ] There are no secrets (passwords, api keys) or userdata in this PR.

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] Issue from task tracker has a link to this pull request (Can be done automatically with [branch names or PR titles](https://support.atlassian.com/jira-software-cloud/docs/reference-issues-in-your-development-work/)).

### Security

- [ ] This PR does not send user data to a new location.
- [ ] This PR does not store new user data or change how we store user data.
- [ ] This PR does not talk to third party services or open new network connections.

If any of these boxes can not be checked, please work with the platform team to identify any risks and ways they can be mitigated.
