### PR TITLE
PLE-767: Adding feature to force subfolders

### DIFF
--- a/conf/default.conf
+++ b/conf/default.conf
@@ -25,7 +25,7 @@ server {
 
   underscores_in_headers on;
 
-  location / {
+  location /$ENV{"SUBPATH"} {
     $ENV{"RATE_LIMIT_LINE_PREFIX"}limit_req zone=ratelimit$ENV{"RATE_LIMIT_BURST"};
 
     proxy_pass            $ENV{"HTTP_PROXY_URL"};

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,8 @@ services:
       - "FQDN=ctcandidate.io-dev.radai"
       - "HTTP_PROXY_URL=http://webserver/"
       - "DEBUG=true"
-      #- "SELF_SIGNED=true"
+      # - "SUBPATH=thispath"
+      # - "SELF_SIGNED=true"
 
   webserver:
     image: nginx

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -21,7 +21,10 @@ if [[ -z "$NX_PROXY_BUFFER_SIZE" ]]; then
   echo "NX_PROXY_BUFFER_SIZE environmental variable is required (nginx proxy_buffers setting)"
   exit 1
 fi
-
+if [[ -z ${SUBPATH} ]]; then
+  echo "SUBPATH environmental variable being set to blank"
+  export SUBPATH=""
+fi
 
 #
 # Optional variables


### PR DESCRIPTION
## Description of the change

> Adding this option to allow subfolders to be able to be used in load balancers, I.E. example.radai.com/thispath can be routed to a URL.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

For production level repositories:

### Development

- [x] The code changed/added as part of this pull request has been covered with tests.
- [x] There are no secrets (passwords, api keys) or userdata in this PR.

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] Issue from task tracker has a link to this pull request (Can be done automatically with [branch names or PR titles](https://support.atlassian.com/jira-software-cloud/docs/reference-issues-in-your-development-work/)).

### Security

- [x] This PR does not send user data to a new location.
- [x] This PR does not store new user data or change how we store user data.
- [x] This PR does not talk to third party services or open new network connections.

If any of these boxes can not be checked, please work with the platform team to identify any risks and ways they can be mitigated.
